### PR TITLE
Awsmethods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/config
 /node_modules
 /frontend/node_modules


### PR DESCRIPTION
Removed the config file from the .gitignore folder and deleted the entire file to update a copy of master without the file.   This should fix the issue of having the key exposed in a previous commit.